### PR TITLE
Update pep-0695.rst for valid Julia syntax

### DIFF
--- a/pep-0695.rst
+++ b/pep-0695.rst
@@ -1495,16 +1495,22 @@ upper and lower bounds on a type.
 
 .. code-block:: julia
 
-    // Generic struct; type parameter with upper and lower bounds
-    struct StructA{T} where Int <: T <: Number
+    # Generic struct; type parameter with upper and lower bounds
+    # Valid for T in (Int64, Signed, Integer, Real, Number)
+    struct Container{Int <: T <: Number}
         x::T
     end
 
-    // Generic function
-    function func1{T <: Real}(v::Container{T})
+    # Generic function
+    function func1(v::Container{T}) where T <: Real end
 
-    // Alternate form of generic function
-    function func2(v::Container{T} where T <: Real)
+    # Alternate forms of generic function
+    function func2(v::Container{T} where T <: Real) end
+    function func3(v::Container{<: Real}) end
+
+    # Tuple types are covariant
+    # Valid for func4((2//3, 3.5))
+    function func4(t::Tuple{Real,Real}) end
 
 Dart
 ----


### PR DESCRIPTION
The syntax for Julia is incorrect. This edit changes the Julia syntax to exhibit valid Julia syntax

```julia
julia> struct StructA{T} where Int <: T <: Number
           x::T
       end
ERROR: syntax: invalid type signature around REPL[1]:1

julia> function func1{T <: Real}(v::Container{T}) end
ERROR: UndefVarError: `func1` not defined
```

